### PR TITLE
removed postgres volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,3 @@ services:
       - POSTGRES_DB=postgres
     ports:
       - "5432:5432"
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Was needed in order to resolve issue where npm run build was trying to access the postgres-data file, but can't due to permission issues. Don't think the volume is necessary