### PR TITLE
Tweak setup scripts and update the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This starts your app in development mode, rebuilding assets on file changes.
 The database seed script creates a new user with some data you can use to get started:
 
 - Email: `rachel@remix.run`
-- Password: `rachelrox`
+- Password: `racheliscool`
 
 If you'd prefer not to use Docker, you can also use Fly's Wireguard VPN to connect to a development database (or even your production database). You can find the instructions to set up Wireguard [here](https://fly.io/docs/reference/private-networking/#install-your-wireguard-app), and the instructions for creating a development database [here](https://fly.io/docs/reference/postgres/).
 
@@ -77,6 +77,8 @@ Prior to your first deployment, you'll need to do a few things:
   fly auth signup
   ```
 
+  > **Note:** If you have more than one Fly account, ensure that you are signed into the same account in the Fly CLI as you are in the browser. In your terminal, run `fly auth whoami` and ensure the email matches the Fly account signed into the browser.
+
 - Create two apps on Fly, one for staging and one for production:
 
   ```sh
@@ -84,7 +86,19 @@ Prior to your first deployment, you'll need to do a few things:
   fly create blues-stack-template-staging
   ```
 
-- Create a new [GitHub Repository](https://repo.new)
+  > **Note:** If you choose a name other than `blues-stack-template`, please note that it must not include spaces. Fly will generate a domain based on the app name you choose at this step.
+
+- Initialize Git.
+
+  ```sh
+  git init
+  ```
+  
+- Create a new [GitHub Repository](https://repo.new), and then add it as the remote for your project. **Do not push your app yet!**
+
+  ```sh
+  git remote add origin <ORIGIN_URL>
+  ```
 
 - Add a `FLY_API_TOKEN` to your GitHub repo. To do this, go to your user settings on Fly and create a new [token](https://web.fly.io/user/personal_access_tokens/new), then add it to [your repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) with the name `FLY_API_TOKEN`.
 
@@ -107,7 +121,15 @@ Prior to your first deployment, you'll need to do a few things:
   fly postgres attach --postgres-app blues-stack-template-staging-db --app blues-stack-template-staging
   ```
 
-  Fly will take care of setting the DATABASE_URL secret for you.
+  > **Note:** When creating the development database, you may get a warning from the Fly CLI that looks like this:
+  >
+  > ```
+  > WARN app flag 'blues-stack-template-staging' does not match app name in config file 'blues-stack-template'
+  > ```
+  >
+  > This simply means that the current directory contains a config that references the production database we created in the first step. Ignore this warning and proceed to create the development database.
+
+Fly will take care of setting the `DATABASE_URL` secret for you.
 
 Now that every is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
   npm run docker
   ```
 
+  > **Note:** The npm script will complete while Docker sets up the container in the background. Ensure that Docker has finished and your container is running before proceeding.
+
 - Initial setup:
 
   ```sh
@@ -45,6 +47,8 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
   ```sh
   npm run dev
   ```
+
+  > **Note:** You may see a nasty error in the PM2 logs when you initially run the dev script. This should only appear once and will not affect your local app server. We are working on improving this!
 
 This starts your app in development mode, rebuilding assets on file changes.
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,12 @@ Prior to your first deployment, you'll need to do a few things:
   fly create blues-stack-template-staging
   ```
 
-  > **Note:** If you choose a name other than `blues-stack-template`, please note that it must not include spaces. Fly will generate a domain based on the app name you choose at this step.
-
 - Initialize Git.
 
   ```sh
   git init
   ```
-  
+
 - Create a new [GitHub Repository](https://repo.new), and then add it as the remote for your project. **Do not push your app yet!**
 
   ```sh
@@ -113,6 +111,14 @@ Prior to your first deployment, you'll need to do a few things:
   fly secrets set SESSION_SECRET=$(openssl rand -hex 32) --app blues-stack-template-staging
   ```
 
+  > **Note:** When creating the staging secret, you may get a warning from the Fly CLI that looks like this:
+  >
+  > ```
+  > WARN app flag 'blues-stack-template-staging' does not match app name in config file 'blues-stack-template'
+  > ```
+  >
+  > This simply means that the current directory contains a config that references the production app we created in the first step. Ignore this warning and proceed to create the secret.
+
   If you don't have openssl installed, you can also use [1password](https://1password.com/generate-password) to generate a random secret, just replace `$(openssl rand -hex 32)` with the generated secret.
 
 - Create a database for both your staging and production environments. Run the following:
@@ -125,13 +131,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly postgres attach --postgres-app blues-stack-template-staging-db --app blues-stack-template-staging
   ```
 
-  > **Note:** When creating the development database, you may get a warning from the Fly CLI that looks like this:
-  >
-  > ```
-  > WARN app flag 'blues-stack-template-staging' does not match app name in config file 'blues-stack-template'
-  > ```
-  >
-  > This simply means that the current directory contains a config that references the production database we created in the first step. Ignore this warning and proceed to create the development database.
+  > **Note:** You'll get the same warning for the same reason when attaching the staging database that you did in the `fly set secret` step above. No worries. Proceed!
 
 Fly will take care of setting the `DATABASE_URL` secret for you.
 

--- a/package.json
+++ b/package.json
@@ -15,16 +15,15 @@
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
     "postinstall": "remix setup node",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
-    "setup": "run-s setup:db setup:app",
-    "setup:app": "run-p \"test -- --run\" lint typecheck test:e2e:run",
-    "setup:db": "prisma migrate dev",
+    "setup": "prisma migrate dev && prisma db seed",
     "start": "cross-env NODE_ENV=production node ./build/server.js",
     "start:mocks": "cross-env NODE_ENV=production node --require ./mocks --require dotenv/config ./build/server.js",
     "test": "vitest",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"cypress open\"",
     "pretest:e2e:run": "npm run build",
     "test:e2e:run": "cross-env PORT=8811 start-server-and-test start:mocks http://localhost:8811 \"cypress run\"",
-    "typecheck": "tsc -b && tsc -b cypress"
+    "typecheck": "tsc -b && tsc -b cypress",
+    "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},
   "eslintIgnore": [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,7 +11,7 @@ async function seed() {
     // no worries if it doesn't exist yet
   });
 
-  const hashedPassword = await bcrypt.hash("rachelrox", 10);
+  const hashedPassword = await bcrypt.hash("racheliscool", 10);
 
   const user = await prisma.user.create({
     data: {


### PR DESCRIPTION
The current setup flow may result in a few errors related to Cypress that we can avoid (at least initially) by removing the test process from the setup script. This PR updates related scripts and updates the README with a bit more nuance during this phase.