### PR TITLE
fix: Make seeding happen only once for Cypress in Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,9 +100,6 @@ jobs:
       - name: 🛠 Setup Database
         run: npx prisma migrate reset --force
 
-      - name: 🌱 Seed the Database
-        run: npx prisma db seed
-
       - name: ⚙️ Build
         run: npm run build
 


### PR DESCRIPTION
Please refer to https://github.com/remix-run/indie-stack/pull/33. I'm pretty sure the same issue happens here as well as `indie-stack`.