### PR TITLE
fix: fixed typo in id for aria error messages

### DIFF
--- a/app/routes/notes/new.tsx
+++ b/app/routes/notes/new.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import { Form, json, redirect, useActionData } from "remix";
 import type { ActionFunction } from "remix";
-
+import { Form, json, redirect, useActionData } from "remix";
 import { createNote } from "~/models/note.server";
 import { requireUserId } from "~/session.server";
 
@@ -75,7 +74,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.title && (
-          <div className="pt-1 text-red-700" id="title=error">
+          <div className="pt-1 text-red-700" id="title-error">
             {actionData.errors.title}
           </div>
         )}
@@ -96,7 +95,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.body && (
-          <div className="pt-1 text-red-700" id="body=error">
+          <div className="pt-1 text-red-700" id="body-error">
             {actionData.errors.body}
           </div>
         )}


### PR DESCRIPTION
Fixed non-matching id's aria-errormessage and id.

Also see https://github.com/remix-run/indie-stack/pull/36 and https://github.com/remix-run/grunge-stack/pull/38