### PR TITLE
More explicit README and configurable env for DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
+DATABASE_PORT=5432
+DATABASE_DB=postgres
+DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@localhost:${DATABASE_PORT}/${DATABASE_DB}"
 SESSION_SECRET="super-duper-s3cret"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
 
 ## Development
 
+- Install dependencies:
+
+  ```sh
+  npm install
+  ```
+
+- Setup environment variables:
+
+  ```sh
+  cp .env.example .env
+  ```
+  
+  > **Note:** This includes some default variables that configure the postgres instance specified in `docker-compose.yml` that you'll run in the next step. In most cases, you don't have to worry about changing these for local development, but if you happen to run several database containers or already have postgres running locally, you may need to consider specifying a separate `DATABASE_PORT` value to avoid conflicts.
+  
 - Start the Postgres Database in [Docker](https://www.docker.com/get-started):
 
   ```sh
@@ -36,7 +50,8 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
 
   > **Note:** The npm script will complete while Docker sets up the container in the background. Ensure that Docker has finished and your container is running before proceeding.
 
-- Initial setup:
+
+- Initial database setup:
 
   ```sh
   npm run setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: postgres:latest
     restart: always
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=postgres
+      - POSTGRES_USER=${DATABASE_USER:-postgres}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-postgres}
+      - POSTGRES_DB=${DATABASE_DB:-postgres}
     ports:
-      - "5432:5432"
+      - ${DATABASE_PORT:-5432}:5432
     volumes:
       - ./postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
I'm not sure how much of the goal is to make things as simple and easily modifiable as possible for users of these stacks - but I would believe that in many cases, devs are likely to already have postgres running on `5432`. So, this just makes things easily configurable in the `.env` and adds to the `README`. 