### PR TITLE
Configure Gitpod for one-click quickstart

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+# Install Fly
+RUN curl -L https://fly.io/install.sh | sh
+ENV FLYCTL_INSTALL="/home/gitpod/.fly"
+ENV PATH="$FLYCTL_INSTALL/bin:$PATH"
+
+# Install GitHub CLI
+RUN brew install gh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,48 @@
+# https://www.gitpod.io/docs/config-gitpod-file
+
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 3000
+    onOpen: notify
+
+tasks:
+  - name: Restore .env file
+    command: |
+      if [ -f .env ]; then
+        # If this workspace already has a .env, don't override it
+        # Local changes survive a workspace being opened and closed
+        # but they will not persist between separate workspaces for the same repo
+
+        echo "Found .env in workspace"
+      else
+        # There is no .env
+        if [ ! -n "${ENV}" ]; then
+          # There is no $ENV from a previous workspace
+          # Default to the example .env
+          echo "Setting example .env"
+
+          cp .env.example .env 
+        else
+          # After making changes to .env, run this line to persist it to $ENV
+          #   eval $(gp env -e ENV="$(base64 .env | tr -d '\n')")
+          # 
+          # Environment variables set this way are shared between all your workspaces for this repo
+          # The lines below will read $ENV and print a .env file
+
+          echo "Restoring .env from Gitpod"
+
+          echo "${ENV}" | base64 -d | tee .env > /dev/null
+        fi
+      fi
+
+  - init: npm install
+    command: npm run setup && npm run dev
+
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker
+    - esbenp.prettier-vscode
+    - dbaeumer.vscode-eslint
+    - bradlc.vscode-tailwindcss

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,7 +42,7 @@ tasks:
     command: docker-compose up
 
   - init: npm install
-    command: npm run setup && gp await-port 5432 && npm run dev
+    command: gp await-port 5432 && npm run setup && npm run dev
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,6 +37,10 @@ tasks:
         fi
       fi
 
+  - name: Docker
+    init: docker-compose pull
+    command: docker-compose up
+
   - init: npm install
     command: npm run setup && npm run dev
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,7 +42,7 @@ tasks:
     command: docker-compose up
 
   - init: npm install
-    command: npm run setup && npm run dev
+    command: npm run setup && gp await-port 5432 && npm run dev
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,7 +42,11 @@ tasks:
     command: docker-compose up
 
   - init: npm install
-    command: gp await-port 5432 && npm run setup && npm run dev
+    command: |
+      gp await-port 5432
+      npm run setup
+      npm run build
+      npm run dev
 
 vscode:
   extensions:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ npx create-remix --template remix-run/blues-stack
 
 Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --template your/repo`! Make it your own.
 
+## Quickstart
+
+Click this button to create a [Gitpod](https://gitpod.io) workspace with the project set up, Postgres started, and Fly pre-installed
+
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
+
 ## Development
 
 - Start the Postgres Database in [Docker](https://www.docker.com/get-started):


### PR DESCRIPTION
I've added Gitpod support to the Blue Stack (here is a similar PR for the Indie Stack https://github.com/remix-run/indie-stack/pull/58)

When a user clicks the Gitpod button, they'll get a workspace with the environment variables set, Fly pre-installed, and the Postgres database running in Docker Compose ready to go. The application starts immediately and a user can create an account and add notes right away.

cc @MichaelDeBoey https://github.com/remix-run/indie-stack/pull/58#issuecomment-1102364419

You can test this workflow by clicking this button:

[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jacobPARIS/blues-stack/)
