### PR TITLE
update setup-test-env.ts to fix jest errors

### DIFF
--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,4 +1,4 @@
 import { installGlobals } from "@remix-run/node/globals";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 
 installGlobals();


### PR DESCRIPTION
I cloned the blues stack tonight and was writing some tests, only to find that when I tried to access the match `toBeInTheDocument` it didn't exist. Updating this line as so made everything work as you'd expect.

Which is kinda odd to me, honestly, because importing the `extend-expect` file should do is run the following code
```
// eslint-disable-next-line
require('./dist/extend-expect')
```

whereas not specifying the file, and using the `main` property in the package.json which points to `dist/index.js` just calls this code 

```
"use strict";

require("./extend-expect");
```

However the latter makes the ts compiler happy

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
