### PR TITLE
ci: add action to test against new remix versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,161 @@
+name: 🚀 Test Against New Remix Version
+
+on:
+  repository_dispatch:
+    types: [remix-release]
+
+jobs:
+  bump:
+    name: 📦 Bump Remix Deps
+    if: github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+
+      - run: |
+          git config user.email "hello@remix.run"
+          git config user.name "Remix Run Bot"
+          git checkout -b remix-release/${{ github.event.client_payload.ref }}
+
+          npm i @remix-run/{node,react,serve,server-runtime}@${{ github.event.client_payload.ref }}
+          npm i -D @remix-run/{dev,eslint-config}@${{ github.event.client_payload.ref }}
+
+          git add .
+          git commit -m "🚀 bump Remix to v${{ github.event.client_payload.ref }}"
+          git push origin remix-release/${{ github.event.client_payload.ref }}
+
+  lint:
+    name: ⬣ ESLint
+    if: github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: remix-release/${{ github.event.client_payload.ref }}
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+
+      - name: 🔬 Lint
+        run: npm run lint
+
+  typecheck:
+    name: ʦ TypeScript
+    if: github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: remix-release/${{ github.event.client_payload.ref }}
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+
+      - name: 🔎 Type check
+        run: npm run typecheck --if-present
+
+  vitest:
+    name: ⚡ Vitest
+    if: github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: remix-release/${{ github.event.client_payload.ref }}
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+
+      - name: ⚡ Run vitest
+        run: npm run test -- --coverage
+
+  cypress:
+    name: ⚫️ Cypress
+    if: github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: remix-release/${{ github.event.client_payload.ref }}
+
+      - name: 🏄 Copy test env vars
+        run: cp .env.example .env
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+
+      - name: 🐳 Docker compose
+        # the sleep is just there to give time for postgres to get started
+        run: docker-compose up -d && sleep 3
+        env:
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
+
+      - name: 🛠 Setup Database
+        run: npx prisma migrate reset --force
+
+      - name: ⚙️ Build
+        run: npm run build
+
+      - name: 🌳 Cypress run
+        uses: cypress-io/github-action@v3
+        with:
+          start: npm run start:mocks
+          wait-on: "http://localhost:8811"
+        env:
+          PORT: "8811"
+
+  cleanup:
+    name: 🗑 Cleanup
+    if: always() && github.repository == 'remix-run/blues-stack'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          git push origin --delete remix-release/${{ github.event.client_payload.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - run: |
-          git config user.email "hello@remix.run"
-          git config user.name "Remix Run Bot"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git checkout -b remix-release/${{ github.event.client_payload.ref }}
 
           npm i @remix-run/{node,react,serve,server-runtime}@${{ github.event.client_payload.ref }}

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -39,6 +39,7 @@ async function main({ rootDirectory }) {
       recursive: true,
     }),
     fs.rm(path.join(rootDirectory, ".github/PULL_REQUEST_TEMPLATE.md")),
+    fs.rm(path.join(rootDirectory, ".github/workflows/test.yml")),
   ]);
 
   const newEnv = env.replace(


### PR DESCRIPTION
receives a [repository_dispatch](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event) event from the Remix repo on new releases so we can bump deps and run the tests against new Remix versions

depends on https://github.com/remix-run/remix/pull/3026

alternatively, instead of duplicating the various test jobs, i think we can have the `deploy` workflow run on all branches instead of just "dev" and "main" and just have this new one bump the deps skedaddle, but then i don't think we can properly clean up and remove the branch

note: we're using the default GitHub Actions bot account so we'll need to enable write permissions for it https://github.com/remix-run/blues-stack/settings/actions

Signed-off-by: Logan McAnsh <logan@mcan.sh>