### PR TITLE
fix: `fly.toml` invalid types

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -41,11 +41,11 @@ processes = []
     timeout = "2s"
 
   [[services.http_checks]]
-    interval = 10000
+    interval = "10s"
     grace_period = "5s"
     method = "get"
     path = "/healthcheck"
     protocol = "http"
-    timeout = 2000
+    timeout = "2s"
     tls_skip_verify = false
     [services.http_checks.headers]


### PR DESCRIPTION
As emitted by VSCode's [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) extension, as recommended by [Fly.io](https://fly.io/docs/reference/configuration/).

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
