### PR TITLE
chore(Dockerfile): conditionally copy package manager lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,18 @@ FROM node:16-bullseye-slim as base
 ENV NODE_ENV production
 
 # Install openssl for Prisma
-RUN apt-get update && apt-get install -y openssl
+RUN apt-get update && apt-get install -y openssl curl
 
 # Install all node_modules, including dev dependencies
 FROM base as deps
 
 WORKDIR /myapp
 
-ADD package.json package-lock.json ./
-RUN npm install --production=false
+ADD package.json ./
+ADD package-lock.jso[n] yarn.loc[k] pnpm-lock.yam[l] pnpm-lock.ym[l] .pnpmfile.cj[s] ./
+# the following script will install the dependencies with which ever lock file is available
+ADD scripts/install-deps.sh ./install-deps.sh
+RUN ./install-deps.sh
 
 # Setup production node_modules
 FROM base as production-deps
@@ -21,8 +24,11 @@ FROM base as production-deps
 WORKDIR /myapp
 
 COPY --from=deps /myapp/node_modules /myapp/node_modules
-ADD package.json package-lock.json ./
-RUN npm prune --production
+ADD package.json ./
+ADD package-lock.jso[n] yarn.loc[k] pnpm-lock.yam[l] pnpm-lock.ym[l] .pnpmfile.cj[s] ./
+# the following script will install the dependencies with which ever lock file is available
+ADD scripts/install-deps.sh ./install-deps.sh
+RUN ./install-deps.sh --prune
 
 # Build the app
 FROM base as build

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+PRUNE=false
+
+while [ $# -gt 0 ] ; do
+  case $1 in
+    -p | --prune) PRUNE=true ;;
+  esac
+  shift
+done
+
+
+if [ -f "yarn.lock" ]; then
+  echo "Installing dependencies from yarn.lock"
+  if [ "$PRUNE" = true ]; then
+    # https://github.com/yarnpkg/yarn/issues/696#issuecomment-258418656
+    yarn install --production --ignore-scripts --prefer-offline
+  else
+    yarn install --production=false
+  fi
+elif [ -f "pnpm-lock.yaml" ] || [ -f "pnpm-lock.yaml" ]; then
+  echo "Installing dependencies from pnpm-lock.yaml"
+  curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
+  if [ "$PRUNE" = true ]; then
+    pnpm prune
+  else
+    pnpm install --production=false
+  fi
+else
+  echo "Installing dependencies from package-lock.json"
+  if [ "$PRUNE" = true ]; then
+    npm prune --production
+  else
+    npm install --production=false
+  fi
+fi


### PR DESCRIPTION
the stack doesn't come with a package-lock.json since #67 causing docker builds to fail, but the file will exist after `create-remix`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
