### PR TITLE
fix: remove `maxAge` from session cookie

### DIFF
--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -10,7 +10,6 @@ export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "__session",
     httpOnly: true,
-    maxAge: 0,
     path: "/",
     sameSite: "lax",
     secrets: [process.env.SESSION_SECRET],


### PR DESCRIPTION
Setting `maxAge: 0` will automatically expire the cookie as soon as it's sent. This should not be the default value. Otherwise, the developer will have to override this on every `set-cookie` header. Leaving it undefined ensures the cookie will live for the life of the browser session.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
