### PR TITLE
chore: add note about running remix init if you skip installing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Click this button to create a [Gitpod](https://gitpod.io) workspace with the pro
 
 ## Development
 
+- This step only applies if you've opted out of having the CLI install dependencies for you:
+
+   ```sh
+   npx remix init
+   ```
+
 - Start the Postgres Database in [Docker](https://www.docker.com/get-started):
 
   ```sh


### PR DESCRIPTION
there's been a few PRs/issues across the official stacks about missing .env files and i haven't heard back whether or not these folks have opted out of the CLI installing deps for them to be certain, but perhaps we add an explicit step about it just in case

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
