### PR TITLE
replace `.lg:pb-18` with a valid classname

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -17,7 +17,7 @@ export default function Index() {
               />
               <div className="absolute inset-0 bg-[color:rgba(27,167,254,0.5)] mix-blend-multiply" />
             </div>
-            <div className="lg:pb-18 relative px-4 pt-16 pb-8 sm:px-6 sm:pt-24 sm:pb-14 lg:px-8 lg:pt-32">
+            <div className="relative px-4 pt-16 pb-8 sm:px-6 sm:pt-24 sm:pb-14 lg:px-8 lg:pb-20 lg:pt-32">
               <h1 className="text-center text-6xl font-extrabold tracking-tight sm:text-8xl lg:text-9xl">
                 <span className="block uppercase text-blue-500 drop-shadow-md">
                   Blues Stack


### PR DESCRIPTION
the classname `.lg:pb-18` doesn't exist in tailwind's default spacing scale. hence why it was being ordered before `.relative`
this replaces it with `.lg:pb-20`