### PR TITLE
chore: remove installGlobals deep import from @remix-run/node

### DIFF
--- a/cypress/support/create-user.ts
+++ b/cypress/support/create-user.ts
@@ -5,7 +5,7 @@
 // as that new user.
 
 import { parse } from "cookie";
-import { installGlobals } from "@remix-run/node/globals";
+import { installGlobals } from "@remix-run/node";
 import { createUserSession } from "~/session.server";
 import { createUser } from "~/models/user.server";
 

--- a/cypress/support/delete-user.ts
+++ b/cypress/support/delete-user.ts
@@ -3,7 +3,7 @@
 // npx ts-node --require tsconfig-paths/register ./cypress/support/delete-user.ts username@example.com
 // and that user will get deleted
 
-import { installGlobals } from "@remix-run/node/globals";
+import { installGlobals } from "@remix-run/node";
 import { prisma } from "~/db.server";
 
 installGlobals();

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,4 +1,4 @@
-import { installGlobals } from "@remix-run/node/globals";
+import { installGlobals } from "@remix-run/node";
 import "@testing-library/jest-dom/extend-expect";
 
 installGlobals();


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
