### PR TITLE
Add note in readme about fly.io app name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Prior to your first deployment, you'll need to do a few things:
   fly create blues-stack-template
   fly create blues-stack-template-staging
   ```
+  
+  > **Note:** Once you've successfully created an app, double-check the `fly.toml` file to ensure that the `app` key is the name of the production app you created. This Stack [automatically appends a unique suffix at init]([url](https://github.com/remix-run/blues-stack/blob/4c2f1af416b539187beb8126dd16f6bc38f47639/remix.init/index.js#L29)) which may not match the apps you created on Fly. You will likely see [404 errors in your Github Actions CI logs]([url](https://community.fly.io/t/404-failure-with-deployment-with-remix-blues-stack/4526/3)) if you have this mismatch.
 
 - Initialize Git.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly create blues-stack-template-staging
   ```
   
-  > **Note:** Once you've successfully created an app, double-check the `fly.toml` file to ensure that the `app` key is the name of the production app you created. This Stack [automatically appends a unique suffix at init]([url](https://github.com/remix-run/blues-stack/blob/4c2f1af416b539187beb8126dd16f6bc38f47639/remix.init/index.js#L29)) which may not match the apps you created on Fly. You will likely see [404 errors in your Github Actions CI logs]([url](https://community.fly.io/t/404-failure-with-deployment-with-remix-blues-stack/4526/3)) if you have this mismatch.
+  > **Note:** Once you've successfully created an app, double-check the `fly.toml` file to ensure that the `app` key is the name of the production app you created. This Stack [automatically appends a unique suffix at init](https://github.com/remix-run/blues-stack/blob/4c2f1af416b539187beb8126dd16f6bc38f47639/remix.init/index.js#L29) which may not match the apps you created on Fly. You will likely see [404 errors in your Github Actions CI logs](https://community.fly.io/t/404-failure-with-deployment-with-remix-blues-stack/4526/3) if you have this mismatch.
 
 - Initialize Git.
 


### PR DESCRIPTION
Super minimal change since I spent a bunch of time tracking this issue down and [Kent welcomed the PR](https://github.com/remix-run/blues-stack/issues/32#issuecomment-1079201097).

Just adding a note that you'll probably want to check the `fly.toml`'s `app` variable.