### PR TITLE
feat: add tailwind input file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ node_modules
 /cypress/videos
 /postgres-data
 
-/app/styles/tailwind.css
+/app/styles/tailwind-build.css

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,4 +8,4 @@ node_modules
 /cypress/videos
 /postgres-data
 
-/app/styles/tailwind.css
+/app/styles/tailwind-build.css

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,7 +13,7 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
-import tailwindStylesheetUrl from "./styles/tailwind.css";
+import tailwindStylesheetUrl from "./styles/tailwind-build.css";
 import { getUser } from "./session.server";
 
 export const links: LinksFunction = () => {

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:css": "cross-env NODE_ENV=development npm run generate:css -- --watch",
     "docker": "docker-compose up -d",
     "format": "prettier --write .",
-    "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
+    "generate:css": "tailwindcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind-build.css",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "setup": "prisma generate && prisma migrate deploy && prisma db seed",
     "start": "cross-env NODE_ENV=production node ./build/server.js",

--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -8,4 +8,4 @@ node_modules
 /cypress/videos
 /postgres-data
 
-/app/styles/tailwind.css
+/app/styles/tailwind-build.css


### PR DESCRIPTION
I propose to use `styles/tailwind.css` as the input file where you can:
- define custom styles and/or font-families
- add tailwind plugins
- use/customize tailwind directives

And move tailwind's output to `styles/tailwind-build.css`.

This does not affect the current behavior and standardizes a widespread use case across people using this template.

For a better reference, you can take a look at the tailwind documentation:

https://tailwindcss.com/docs/adding-custom-styles#using-css-and-layer