### PR TITLE
Check if FLY_REGION is undefined

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -33,7 +33,7 @@ function getClient() {
 
   const isReadReplicaRegion = !PRIMARY_REGION || PRIMARY_REGION === FLY_REGION;
 
-  if (!isLocalHost) {
+  if (!isLocalHost && FLY_REGION !== undefined) {
     databaseUrl.host = `${FLY_REGION}.${databaseUrl.host}`;
     if (!isReadReplicaRegion) {
       // 5433 is the read-replica port


### PR DESCRIPTION
Small change to check if FLY_REGION env var is undefined so Prisma can connect to the proper non localhost or fly database.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
