### PR TITLE
added a visitAndCheck function to make sure that the DOM has been mou…

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -12,7 +12,7 @@ describe("smoke tests", () => {
     };
     cy.then(() => ({ email: loginForm.email })).as("user");
 
-    cy.visit("/");
+    cy.visitAndCheck("/");
     cy.findByRole("link", { name: /sign up/i }).click();
 
     cy.findByRole("textbox", { name: /email/i }).type(loginForm.email);
@@ -30,7 +30,7 @@ describe("smoke tests", () => {
       body: faker.lorem.sentences(1),
     };
     cy.login();
-    cy.visit("/");
+    cy.visitAndCheck("/");
 
     cy.findByRole("link", { name: /notes/i }).click();
     cy.findByText("No notes yet");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,6 +26,18 @@ declare global {
        *    cy.cleanupUser({ email: 'whatever@example.com' })
        */
       cleanupUser: typeof cleanupUser;
+
+      /**
+       * Extends the standard visit command to wait for the page to load
+       *
+       * @returns {typeof visitAndCheck}
+       * @memberof Chainable
+       * @example
+       *    cy.visitAndCheck('/')
+       *  @example
+       *    cy.visitAndCheck('/', 500)
+       */
+      visitAndCheck: typeof visitAndCheck;
     }
   }
 }
@@ -68,8 +80,19 @@ function deleteUserByEmail(email: string) {
   cy.clearCookie("__session");
 }
 
+// We're waiting a second because of this issue happen randomly
+// https://github.com/cypress-io/cypress/issues/7306
+// Also added custom types to avoid getting detached
+// https://github.com/cypress-io/cypress/issues/7306#issuecomment-1152752612
+// ===========================================================
+function visitAndCheck(url: string, waitTime: number = 1000) {
+  cy.visit(url);
+  cy.location("pathname").should("contain", url).wait(waitTime);
+}
+
 Cypress.Commands.add("login", login);
 Cypress.Commands.add("cleanupUser", cleanupUser);
+Cypress.Commands.add("visitAndCheck", visitAndCheck);
 
 /*
 eslint


### PR DESCRIPTION
Currently the cypress suites fail constantly because of Cypress and React Hydrating the document.

Added a visitAndCheck command which makes sure that the app has been mounted onto the DOM before we continue the tests.

Based off https://github.com/remix-run/indie-stack/pull/131