### PR TITLE
chore(deps): upgrade vitest and add @vitest/coverage-c8 dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.0",
+    "@vitest/coverage-c8": "^0.22.0",
     "autoprefixer": "^10.4.7",
     "c8": "^7.11.3",
     "cookie": "^0.5.0",
@@ -88,7 +89,7 @@
     "typescript": "^4.7.4",
     "vite": "^3.0.0",
     "vite-tsconfig-paths": "^3.5.0",
-    "vitest": "^0.18.0"
+    "vitest": "^0.22.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->

Just getting ahead of this: Vitest v0.22.0 [now requires](https://github.com/vitest-dev/vitest/releases/tag/v0.22.0) that the `@vitest/coverage-c8` peer dependency also be installed if running with coverage, or it will fail. 
