### PR TITLE
Fix delete user command hang on windows

### DIFF
--- a/cypress/support/delete-user.ts
+++ b/cypress/support/delete-user.ts
@@ -28,6 +28,8 @@ async function deleteUser(email: string) {
     } else {
       throw error;
     }
+  } finally {
+    await prisma.$disconnect();
   }
 }
 


### PR DESCRIPTION
Something about how the windows prisma client works prevents the script from exiting on windows casuing the cypress e2e tests to hang. Explictly disconnecting the prisma client allows the script to exit.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
