### PR TITLE
fix(eslint): ignore postgres-data folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "eslintIgnore": [
     "/node_modules",
     "/build",
-    "/public/build"
+    "/public/build",
+    "/postgres-data"
   ],
   "dependencies": {
     "@prisma/client": "^4.2.1",


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->

Once `postgres-data` folder is created by the PostgreSQL Docker container, ESLint starts to fail because it cannot access this folder as it's owned by a different user. This folder is already included in `.gitignore` and I think it should also be ignored by ESLint since it only contains DB data.