### PR TITLE
fix: update `msw`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",
     "happy-dom": "^6.0.4",
-    "msw": "^0.45.0",
+    "msw": "^0.47.3",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.16",
     "prettier": "^2.7.1",


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->

Fixes an issue with MSW  (
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib' is not defined by "exports" in <home directory>/node_modules/headers-polyfill/package.json)

MSW recent release [0.47.3](https://github.com/mswjs/msw/pull/1407) fixes the issue. 
