### PR TITLE
docs: use latest `create-remix` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Learn more about [Remix Stacks](https://remix.run/stacks).
 
 ```
-npx create-remix --template remix-run/blues-stack
+npx create-remix@latest --template remix-run/blues-stack
 ```
 
 ## What's in the stack


### PR DESCRIPTION
When i use the current command, it goes through the normal `create-remix` steps rather than using this template.