### PR TITLE
feat: add Fly/Grafana metrics

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,11 @@ processes = []
 
 [env]
   PORT = "8080"
+  METRICS_PORT = "8081"
+
+[metrics]
+  port = 8081
+  path = "/metrics"
 
 [deploy]
   release_command = "npx prisma migrate deploy"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "express": "^4.18.1",
+    "express-prometheus-middleware": "^1.2.0",
     "isbot": "^3.5.3",
     "morgan": "^1.10.0",
+    "prom-client": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tiny-invariant": "^1.2.0"
@@ -62,6 +64,7 @@
     "@types/compression": "^1.7.2",
     "@types/eslint": "^8.4.6",
     "@types/express": "^4.17.14",
+    "@types/express-prometheus-middleware": "^1.2.1",
     "@types/morgan": "^1.9.3",
     "@types/node": "^18.7.18",
     "@types/react": "^18.0.20",

--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,7 @@ import express from "express";
 import compression from "compression";
 import morgan from "morgan";
 import { createRequestHandler } from "@remix-run/express";
+import prom from "express-prometheus-middleware";
 
 const app = express();
 
@@ -88,6 +89,18 @@ app.listen(port, () => {
   // require the built app so we're ready when the first request comes in
   require(BUILD_DIR);
   console.log(`✅ app ready: http://localhost:${port}`);
+});
+
+const metrics = express();
+const metricsPort = process.env.METRICS_PORT || 3001;
+metrics.use(
+  prom({
+    metricsPath: "/metrics",
+    collectDefaultMetrics: true,
+  })
+);
+metrics.listen(metricsPort, () => {
+  console.log(`✅ metrics ready: http://localhost:${metricsPort}/metrics`);
 });
 
 function purgeRequireCache() {


### PR DESCRIPTION
Since fly.io now offers Grafana instance (https://fly-metrics.net) it could be useful to add metrics to the stack
