### PR TITLE
Make email unique constraint case insensitive

### DIFF
--- a/prisma/migrations/20221222141632_init/migration.sql
+++ b/prisma/migrations/20221222141632_init/migration.sql
@@ -1,7 +1,10 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "citext";
+
 -- CreateTable
 CREATE TABLE "User" (
     "id" TEXT NOT NULL,
-    "email" TEXT NOT NULL,
+    "email" CITEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,15 +1,17 @@
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [citext]
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 model User {
   id    String @id @default(cuid())
-  email String @unique
+  email String @unique @db.Citext
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
Fixes #140 by making the `user.email` column [`citext`](https://www.postgresql.org/docs/current/citext.html) instead of `text`.

Now, unlike before, if you try and sign up with `Test@example.com` after signing up with `test@example.com`, you will be correctly informed that a user with that email already exists.