### PR TITLE
fix: opt out of known-vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "/postgres-data"
   ],
   "dependencies": {
+    "@isaacs/express-prometheus-middleware": "^1.2.1",
     "@prisma/client": "^4.9.0",
     "@remix-run/express": "*",
     "@remix-run/node": "*",
@@ -43,7 +44,6 @@
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "express": "^4.18.2",
-    "express-prometheus-middleware": "^1.2.0",
     "isbot": "^3.6.5",
     "morgan": "^1.10.0",
     "prom-client": "^14.1.1",
@@ -64,7 +64,6 @@
     "@types/compression": "^1.7.2",
     "@types/eslint": "^8.4.10",
     "@types/express": "^4.17.15",
-    "@types/express-prometheus-middleware": "^1.2.1",
     "@types/morgan": "^1.9.4",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.26",

--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import express from "express";
 import compression from "compression";
 import morgan from "morgan";
 import { createRequestHandler } from "@remix-run/express";
-import prom from "express-prometheus-middleware";
+import prom from "@isaacs/express-prometheus-middleware";
 
 const app = express();
 const metricsApp = express();


### PR DESCRIPTION
The express-prometheus-middleware is no longer maintained, and it has an optional dependency on gc-stats (also abandoned), which pulls in outdated and insecure versions of several modules, causing npm audit and other security checkers to complain.

This replaces express-prometheus-middleware with a fork that does not pull in the insecure dependencies.

A better solution would be to replace the module entirely with another prometheus implementation, but this at least avoids the security issue in as unobtrusive a manner as possible, so while not the ideal fix, it is an improvement.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
