### PR TITLE
fix: correct cover image `alt` tag

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,7 +16,7 @@ export default function Index() {
               <img
                 className="h-full w-full object-cover"
                 src="https://user-images.githubusercontent.com/1500684/158276320-c46b661b-8eff-4a4d-82c6-cf296c987a12.jpg"
-                alt="BB King playing blues on his Les Paul guitar"
+                alt="BB King playing blues on his Gibson 'Lucille' guitar"
               />
               <div className="absolute inset-0 bg-[color:rgba(27,167,254,0.5)] mix-blend-multiply" />
             </div>


### PR DESCRIPTION
Pedantic fix to the accuracy of the alt tag on the hero image.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
