### PR TITLE
fix: don't add `FLY_REGION` prefix when using recent `flyctl` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ Prior to your first deployment, you'll need to do a few things:
 
 - [Install Fly](https://fly.io/docs/getting-started/installing-flyctl/)
 
-- Make sure you're on version v0.0.474 or greater
-
-  ```sh
-  fly version
-  ```
-
 - Sign up and log in to Fly
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Prior to your first deployment, you'll need to do a few things:
 
 - [Install Fly](https://fly.io/docs/getting-started/installing-flyctl/)
 
+- Make sure you're on version v0.0.474 or greater
+
+  ```sh
+  fly version
+  ```
+
 - Sign up and log in to Fly
 
   ```sh

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -34,7 +34,6 @@ function getClient() {
   const isReadReplicaRegion = !PRIMARY_REGION || PRIMARY_REGION === FLY_REGION;
 
   if (!isLocalHost) {
-    databaseUrl.host = `${FLY_REGION}.${databaseUrl.host}`;
     if (!isReadReplicaRegion) {
       // 5433 is the read-replica port
       databaseUrl.port = "5433";

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -34,6 +34,10 @@ function getClient() {
   const isReadReplicaRegion = !PRIMARY_REGION || PRIMARY_REGION === FLY_REGION;
 
   if (!isLocalHost) {
+    if (databaseUrl.host.endsWith('.internal')) {
+      databaseUrl.host = `${FLY_REGION}.${databaseUrl.host}`;
+    }
+
     if (!isReadReplicaRegion) {
       // 5433 is the read-replica port
       databaseUrl.port = "5433";


### PR DESCRIPTION
New versions of `flyctl`, when running `fly postgres attach`, use [flycast](https://fly.io/docs/reference/private-networking/#flycast-private-load-balancing) URLs to connect to the DB. This provides the same geo-aware load balancing that the stack already achieves today by prefixing the hostname with the region. Flycast doesn't support region prefixes. This has been causing failures for new apps.

For example:

Old: `postgres://top2.nearest.of.my-postgres.internal`
New: `postgres://my-postgres.flycast`

The old format supports a region prefix, but the new one does not.

Fixes #182

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
