### PR TITLE
chore: expand init instructions, clean after init

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ Click this button to create a [Gitpod](https://gitpod.io) workspace with the pro
 
 ## Development
 
-- This step only applies if you've opted out of having the CLI install dependencies for you:
+- First run this stack's `remix.init` script and commit the changes it makes to your project.
 
   ```sh
   npx remix init
+  git init # if you haven't already
+  git add .
+  git commit -m "Initialize project"
   ```
 
 - Start the Postgres Database in [Docker](https://www.docker.com/get-started):

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -209,10 +209,20 @@ const main = async ({ isTypeScript, packageManager, rootDirectory }) => {
   const prodToml = toml.parse(prodContent);
   prodToml.app = prodToml.app.replace(REPLACER, APP_NAME);
 
-  const newReadme = readme.replace(
-    new RegExp(escapeRegExp(REPLACER), "g"),
-    APP_NAME
-  );
+  const initInstructions = `
+- First run this stack's \`remix.init\` script and commit the changes it makes to your project.
+
+  \`\`\`sh
+  npx remix init
+  git init # if you haven't already
+  git add .
+  git commit -m "Initialize project"
+  \`\`\`
+`;
+
+  const newReadme = readme
+    .replace(new RegExp(escapeRegExp(REPLACER), "g"), APP_NAME)
+    .replace(initInstructions, "");
 
   const newDockerfile = pm.lockfile
     ? dockerfile.replace(


### PR DESCRIPTION
This change was motivated by some upcoming work in `create-remix` but this is still a useful change in the meantime that can go out immediately.

From an end user perspective, if the `remix.init` script runs during the `create-remix` flow, the `npx remix init` instructions are no longer present in the readme since they're redundant and just add noise.

For those that didn't already run the `remix.init` script (either because they opted out of installing dependencies, or because they cloned this repo directly), the instructions are now much clearer since they're not conditional — you don't have to remember whether or not you opted out of installing dependencies anymore. We also now make it clear that this script makes changes to your project that are intended to be committed.