### PR TITLE
fix: cypress types for typescript > 5.1

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -20,8 +20,11 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "typeRoots": ["../types", "../node_modules/@types"],
-
+    "typeRoots": [
+      "../node_modules",
+      "../types", 
+      "../node_modules/@types"
+    ],
     "paths": {
       "~/*": ["../app/*"]
     }


### PR DESCRIPTION
Solution [as suggested](https://github.com/remix-run/blues-stack/issues/190#issuecomment-1602806268) by Cypress' @jordanpowell88. 

More info here: https://github.com/cypress-io/cypress/issues/26930
