### PR TITLE
fix: add 'keep-alive' header to healthcheck.tsx

### DIFF
--- a/app/routes/healthcheck.tsx
+++ b/app/routes/healthcheck.tsx
@@ -13,7 +13,10 @@ export const loader = async ({ request }: LoaderArgs) => {
     // and make a HEAD request to ourselves, then we're good.
     await Promise.all([
       prisma.user.count(),
-      fetch(url.toString(), { method: "HEAD" }).then((r) => {
+      fetch(url.toString(), {
+        method: "HEAD",
+        headers: { connection: "keep-alive" },
+      }).then((r) => {
         if (!r.ok) return Promise.reject(r);
       }),
     ]);


### PR DESCRIPTION
This fix resolves an issue where the healthcheck would fail because the connection would close prematurely.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
