### PR TITLE
Fixed: Duplicate request handlers being produced

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -90,17 +90,13 @@ async function run() {
 
   app.use(morgan("tiny"));
 
-  app.all("*", async (...args) => {
-    const handler =
-      process.env.NODE_ENV === "development"
-        ? await createDevRequestHandler(initialBuild)
-        : createRequestHandler({
-            build: initialBuild,
-            mode: initialBuild.mode,
-          });
-
-    return handler(...args);
-  });
+  app.all("*", process.env.NODE_ENV === "development"
+    ? await createDevRequestHandler(initialBuild)
+    : createRequestHandler({
+      build: initialBuild,
+      mode: initialBuild.mode,
+    })
+  );
 
   const port = process.env.PORT || 3000;
   app.listen(port, () => {


### PR DESCRIPTION
Without this fix you would end up with multiple request handlers being created which seems unnecessary and also somewhat harmful for the `createDevRequestHandler`.

Plus with duplicate `devReq` handlers were was a state issue occurring where where multiple rebuilds would be issued at the same time interfering with each other and occasionally but not always breaking hot reloading

**Fix validation**
To validate this fix you can replace the `createDevRequestHandler` with the snippet below, and change a few files while having a tab open, and notice that `c` does not count up consistently, and sometimes get's stuck not counting at all.
```ts
async function createDevRequestHandler(
	initialBuild: ServerBuild,
): Promise<RequestHandler> {
	console.log('handler birthed');
	let c = 0;
	let build = initialBuild;
	async function handleServerUpdate() {
		console.log('update');
		build = await reimportServer();  // 1. re-import the server build
		broadcastDevReady(build);        // 2. tell Remix that this app server is now up-to-date and ready
		c++;
	}
	const chokidar = await import("chokidar");
	chokidar
		.watch(VERSION_PATH, { ignoreInitial: true })
		.on("add", handleServerUpdate)
		.on("change", handleServerUpdate);

	// wrap request handler to make sure its recreated with the latest build for every request
	return async (req, res, next) => {
		console.log('req received to ', c);
		try {
			return createRequestHandler({
				build,
				mode: "development",
			})(req, res, next);
		} catch (error) {
			next(error);
		}
	};
}
```
